### PR TITLE
Add support for git subcommands

### DIFF
--- a/bashelp.sh
+++ b/bashelp.sh
@@ -66,11 +66,11 @@ _bash_help () {
     fi
 
     # Check special cases
-    if [ "$CMD" = "git" ]
+    if [ "$CMD" = "btrfs" -o "$CMD" = "flatpak" -o "$CMD" = "git" -o "$CMD" = "openssl" -o "$CMD" = "ostree" ]
     then
         local token_no_cmd=${TOKEN#* }
         local subcmd=${token_no_cmd%% *}
-        # If there's a manual for this git subcommand, use that as CMD
+        # If there's a manual for this subcommand, use that as CMD
         if man -w "$CMD-$subcmd" &>/dev/null
         then
             CMD="$CMD-$subcmd"

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -65,6 +65,18 @@ _bash_help () {
 	return
     fi
 
+    # Check special cases
+    if [ "$CMD" = "git" ]
+    then
+        TOKEN_NO_CMD=${TOKEN#* }
+        SUBCMD=${TOKEN_NO_CMD%% *}
+        # If there's a manual for this git subcommand, use that as CMD
+        if man -w "$CMD-$SUBCMD" &>/dev/null
+        then
+            CMD="$CMD-$SUBCMD"
+        fi
+    fi
+
 # construct command
     HELP="$MANPGM \"$PREFIX$CMD\" ; exit "
 

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -68,12 +68,12 @@ _bash_help () {
     # Check special cases
     if [ "$CMD" = "git" ]
     then
-        TOKEN_NO_CMD=${TOKEN#* }
-        SUBCMD=${TOKEN_NO_CMD%% *}
+        local token_no_cmd=${TOKEN#* }
+        local subcmd=${token_no_cmd%% *}
         # If there's a manual for this git subcommand, use that as CMD
-        if man -w "$CMD-$SUBCMD" &>/dev/null
+        if man -w "$CMD-$subcmd" &>/dev/null
         then
-            CMD="$CMD-$SUBCMD"
+            CMD="$CMD-$subcmd"
         fi
     fi
 


### PR DESCRIPTION
`git help` shows manpages for git subcommands, named of the form `git-subcommand`.  Therefore, it's possible to use any man reader to show git help pages.

This commit makes it so when CMD is "git", a second word is read and the existence of the corresponding git help page is tested.  If it exists, that is the man page that's shown; otherwise the man page for git itself is shown.