### PR TITLE
Add support for GNU Screen and GNOME Terminal

### DIFF
--- a/bashelp.sh
+++ b/bashelp.sh
@@ -24,6 +24,7 @@ _bash_help () {
     MANOPT=
     # If using a GUI MANPGM (yelp, gman, etc.) Set TERMINAL to blank (TERMINAL=)
     # Set TERMINAL=screen to show man pages in the current terminal with GNU Screen
+    # GNOME Terminal is supported (TERMINAL=gnome-terminal)
     # Other terminals must accept the same options as xterm
     TERMINAL=xterm
 

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -76,6 +76,9 @@ _bash_help () {
             "")
                 ( "$MANPGM" $MANOPT "$PREFIX$CMD" &) &>/dev/null   # must be a GUI man?
                 ;;
+            gnome-terminal)
+                ("$TERMINAL" --geometry="$SIZE" -- $MANPGM "$PREFIX$CMD")
+                ;;
             screen)
                 "$TERMINAL" $MANPGM "$PREFIX$CMD"
                 ;;

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -78,7 +78,7 @@ _bash_help () {
                 ( "$MANPGM" $MANOPT "$PREFIX$CMD" &) &>/dev/null   # must be a GUI man?
                 ;;
             gnome-terminal)
-                ("$TERMINAL" --geometry="$SIZE" -- $MANPGM "$PREFIX$CMD")
+                "$TERMINAL" --geometry="$SIZE" -- $MANPGM "$PREFIX$CMD"
                 ;;
             screen)
                 "$TERMINAL" $MANPGM "$PREFIX$CMD"

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -24,7 +24,8 @@ _bash_help () {
     MANOPT=
     # If using a GUI MANPGM (yelp, gman, etc.) Set TERMINAL to blank (TERMINAL=)
     # Set TERMINAL=man to show man pages in the current terminal with MANPGM
-    # Set TERMINAL=screen to show man pages in the current terminal with GNU Screen
+    # Set TERMINAL=screen to show man pages in a new window of GNU Screen
+    # Set TERMINAL=tmux to show man pages in a new window of tmux
     # GNOME Terminal is supported (TERMINAL=gnome-terminal)
     # Other terminals must accept the same options as xterm
     TERMINAL=xterm
@@ -52,6 +53,7 @@ _bash_help () {
     case $TERMINAL in
         man) ;;
         screen) ;;
+        tmux) ;;
         *)
             if [ -z "$DISPLAY" ]
             then
@@ -86,6 +88,9 @@ _bash_help () {
                 ;;
             screen)
                 "$TERMINAL" $MANPGM "$PREFIX$CMD"
+                ;;
+            tmux)
+                "$TERMINAL" new-window $MANPGM "$PREFIX$CMD"
                 ;;
             *)
                 # execute without job control noise

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -23,6 +23,7 @@ _bash_help () {
     # MANOPT is usually empty unless you need to pass -H to man or some other option
     MANOPT=
     # If using a GUI MANPGM (yelp, gman, etc.) Set TERMINAL to blank (TERMINAL=)
+    # Set TERMINAL=man to show man pages in the current terminal with MANPGM
     # Set TERMINAL=screen to show man pages in the current terminal with GNU Screen
     # GNOME Terminal is supported (TERMINAL=gnome-terminal)
     # Other terminals must accept the same options as xterm
@@ -49,8 +50,8 @@ _bash_help () {
 
 # Don't try to help people in a console/TTY if TERMINAL isn't known to work
     case $TERMINAL in
-        screen)
-            ;;
+        man) ;;
+        screen) ;;
         *)
             if [ -z "$DISPLAY" ]
             then
@@ -79,6 +80,9 @@ _bash_help () {
                 ;;
             gnome-terminal)
                 "$TERMINAL" --geometry="$SIZE" -- $MANPGM "$PREFIX$CMD"
+                ;;
+            man)
+                $MANPGM "$PREFIX$CMD"
                 ;;
             screen)
                 "$TERMINAL" $MANPGM "$PREFIX$CMD"


### PR DESCRIPTION
Not all terminals support the same command-line arguments as xterm.  It would be nice to not leave those terminals out in the cold, so this patch refactors the script to allow terminals that don't work like xterm to have special commands run.

Of course, this adds support for two such terminals:  GNU Screen and GNOME Terminal.  GNOME Terminal was simple to support (just a different set of command-line arguments from xterm), but for Screen some extra changes were needed to allow it to work in a TTY.  I can't figure out how to silence the `[screen is terminating]` message (apparently it's neither stdout nor stderr?), but other than that it works great.