### PR TITLE
Configuration through environment variables, only declare locals in _bash_help

### DIFF
--- a/bashelp.sh
+++ b/bashelp.sh
@@ -63,63 +63,63 @@ _bash_help () {
     esac
 
 # Get command name
-    TOKEN="${READLINE_LINE:0:${READLINE_POINT}}"
+    local token="${READLINE_LINE:0:${READLINE_POINT}}"
 # find first part of command line
-    CMD=${TOKEN%% *}
+    local cmd=${token%% *}
     # If we don't know about this program, skip it
     # don't redirect stderr since that is helpful
     # we assume the system man knows about everything the other man programs might know
-    if ! man -w "$CMD" >/dev/null
+    if ! man -w "$cmd" >/dev/null
     then
 	return
     fi
 
     # Check special cases
-    if [ "$CMD" = "btrfs" -o "$CMD" = "flatpak" -o "$CMD" = "git" -o "$CMD" = "openssl" -o "$CMD" = "ostree" ]
+    if [ "$cmd" = "btrfs" -o "$cmd" = "flatpak" -o "$cmd" = "git" -o "$cmd" = "openssl" -o "$cmd" = "ostree" ]
     then
-        local token_no_cmd=${TOKEN#* }
+        local token_no_cmd=${token#* }
         local subcmd=${token_no_cmd%% *}
-        # If there's a manual for this subcommand, use that as CMD
-        if man -w "$CMD-$subcmd" &>/dev/null
+        # If there's a manual for this subcommand, use that as cmd
+        if man -w "$cmd-$subcmd" &>/dev/null
         then
-            CMD="$CMD-$subcmd"
+            cmd="$cmd-$subcmd"
         fi
     fi
 
 # construct command
-    HELP="$MANPGM \"$PREFIX$CMD\" ; exit "
+    cmd_pref="$PREFIX$cmd"
 
     if [ "$USEBROWSER" == 0 ]
     then
         case $TERMINAL in
             "")
-                ( "$MANPGM" $MANOPT "$PREFIX$CMD" &) &>/dev/null   # must be a GUI man?
+                ( "$MANPGM" $MANOPT "$cmd_pref" &) &>/dev/null   # must be a GUI man?
                 ;;
             gnome-terminal)
-                "$TERMINAL" --geometry="$SIZE" -- $MANPGM "$PREFIX$CMD"
+                "$TERMINAL" --geometry="$SIZE" -- $MANPGM "$cmd_pref"
                 ;;
             man)
-                $MANPGM "$PREFIX$CMD"
+                $MANPGM "$cmd_pref"
                 ;;
             screen)
-                "$TERMINAL" $MANPGM "$PREFIX$CMD"
+                "$TERMINAL" $MANPGM "$cmd_pref"
                 ;;
             tmux)
-                "$TERMINAL" new-window $MANPGM "$PREFIX$CMD"
+                "$TERMINAL" new-window $MANPGM "$cmd_pref"
                 ;;
             *)
                 # execute without job control noise
-                ("$TERMINAL" -geometry "$SIZE" -e "$MANPGM \"$PREFIX$CMD\"; exit" &)
+                ("$TERMINAL" -geometry "$SIZE" -e "$MANPGM \"$cmd_pref\"; exit" &)
                 ;;
         esac
     else
 	if [ -z "$SITE" ]
 	then
 	    export BROWSER
-	    ("$MANPGM" $MANOPT "$PREFIX$CMD" &) &>/dev/null  # catch messages from browser & job control
+	    ("$MANPGM" $MANOPT "$cmd_pref" &) &>/dev/null  # catch messages from browser & job control
 	else
 # if you are more a web kind of guy/gal try this
-	    ( xdg-open "$SITE$CMD" &)
+	    ( xdg-open "$SITE$cmd" &)
 	fi
     fi
     }

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -3,47 +3,6 @@
 # Bind to ^Y although obviously you could pick something else
 bind -x '"\C-Y":_bash_help'
 
-# Options
-#
-# You can run man in an xterm (or equivalent) by setting:
-#
-#     BASHELP_MANPGM=man
-#     BASHELP_TERMINAL=xterm
-#     BASHELP_USEBROWSER=0
-#
-# Note that these are the default settings if the BASHELP environment variables
-# are unset.
-#
-# Supported values for BASHELP_TERMINAL are:
-#
-# * man (runs man in the current terminal)
-# * screen (shows man pages in a new window of GNU Screen)
-# * tmux (shows man pages in a new window of tmux)
-# * gnome-terminal
-# * Any terminal that takes the same command-line options as xterm
-#
-# Graphical terminals can be passed options using BASHELP_TERMOPT.
-#
-# Or, you can run a GUI man reader like yelp by setting:
-#
-#     BASHELP_MANPGM="yelp"
-#     BASHELP_PREFIX="man:"
-#     BASHELP_TERMINAL=
-#     BASHELP_USEBROWSER=0
-#
-# Or, you can open a web site using the default web browser by setting:
-#
-#     BASHELP_USEBROWSER=1
-#     BASHELP_SITE="http://man.he.net/?section=all&topic=" #(or equivalent)
-#
-# Or, you can open a local man page in a browser by setting:
-#
-#     BASHELP_MANPGM=man
-#     BASHELP_USEBROWSER=1
-#     BASHELP_SITE=
-#     BASHELP_MANOPT="-H "
-#     BROWSER=google-chrome
-
 _bash_help () {
     # Program used to show man pages, probably man or some graphical man reader
     local manpgm=${BASHELP_MANPGM-man}

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -64,7 +64,7 @@ _bash_help () {
     fi
 
 # construct command
-    cmd_pref="$prefix$cmd"
+    local cmd_pref="$prefix$cmd"
 
     if [ "$usebrowser" == 0 ]
     then

--- a/readme.md
+++ b/readme.md
@@ -5,25 +5,53 @@ Offer help at the bash command prompt. Al Williams
 
 Usage
 ---
-. bashelp.sh
+
+    . bashelp.sh
 
 Near the start of the file is a line:
+
     bind -x '"\C-Y":_bash_help'
 
-You can change the key from ^Y to something else by changing this line and sourcing the file again.
+You can change the key from <kbd>Ctrl</kbd> + <kbd>Y</kbd> to something else by
+changing this line and sourcing the file again.
 
-You may want to edit some of the other configuration parameters near the top:
-* MANPGM - The name of your man program. Usually man unless you want a GUI (yelp, khelpcenter, gman, xman)
-* PREFIX - If you need a prefix on the man topic (e.g., man:ls for ls, you set this to man:)
-* MANOPT - If you need to pass an option to your man program (e.g., -H)
-* TERMINAL - Set if using a CLI-based man (usually set to xterm)
-* USEBROWSER - Set to 0 to run MANPGM in its own window
-* SITE - If USEBROWSER=1 use a web browser to get the man page on the Internet (set up for http://man.he.net)
-* SIZE - Size of terminal window (not used when TERMINAL is blank)
+Options
+-------
 
-Common setups:
-* Normal man in a new shell: MANPGM=man TERMINAL=xterm USEBROWSER=0 SIZE=132x48+0+0
-* KDE Help: MANPGM=khelpcenter PREFIX=man: USEBROWSER=0
-* Web: USEBROWSER=1 SITE="http://man.he.net/?section=all&topic="
-* Local Browser: MANPGM=man MANOPT=-H USEBROWSER=1 BROWSER=google-chrome
+The way that bashelp shows man pages can be configured through environment
+variables, without modifying the script itself.  The default settings, shown
+below, tell bashelp to run man in an xterm:
 
+    BASHELP_MANPGM=man
+    BASHELP_TERMINAL=xterm
+    BASHELP_USEBROWSER=0
+
+Supported values for `BASHELP_TERMINAL` are:
+
+* `man` (runs man in the current terminal)
+* `screen` (shows man pages in a new window of GNU Screen)
+* `tmux` (shows man pages in a new window of tmux)
+* `gnome-terminal`
+* Any terminal that takes the same command-line options as xterm
+
+Graphical terminals can be passed additional options using `BASHELP_TERMOPT`.
+
+Or, you can run a GUI man reader like yelp by setting:
+
+    BASHELP_MANPGM="yelp"
+    BASHELP_PREFIX="man:"
+    BASHELP_TERMINAL=
+    BASHELP_USEBROWSER=0
+
+Or, you can open a web site using the default web browser by setting:
+
+    BASHELP_USEBROWSER=1
+    BASHELP_SITE="http://man.he.net/?section=all&topic=" #(or equivalent)
+
+Or, you can open a local man page in a browser by setting:
+
+    BASHELP_MANPGM=man
+    BASHELP_USEBROWSER=1
+    BASHELP_SITE=
+    BASHELP_MANOPT="-H "
+    BROWSER=google-chrome


### PR DESCRIPTION
This patch makes the _bash_help function declare only local variables, to avoid polluting the environment of other programs.  Additionally, the settings in the _bash_help function can now be set through environment variables, e.g. `BASHELP_TERMINAL`.  The old `SIZE` option has been replaced with `BASHELP_TERMOPT`, which can contain any command-line options to the graphical terminal rather than just geometry.