### PR TITLE
Gracefully handle command chaining

### DIFF
--- a/bashelp.sh
+++ b/bashelp.sh
@@ -41,10 +41,9 @@ _bash_help () {
 
     # Get command up to the cursor
     local token="${READLINE_LINE:0:${READLINE_POINT}}"
-    # Remove everything before the last pipe
-    token=${token##*|}
-    # Strip leading whitespace
-    token="$(echo -e "${token}" | sed -e 's/^[[:space:]]*//')"
+    # Strip everything before and including the last pipe, ampersand, or
+    # semicolon, and all the whitespace immediately thereafter
+    token="$(echo -e "${token}" | sed -e 's/^\(.*[|&;]\)*[[:space:]]*//')"
     # Get the first word of token
     local cmd=${token%% *}
     # If we don't know about this program, skip it

--- a/bashelp.sh
+++ b/bashelp.sh
@@ -39,9 +39,13 @@ _bash_help () {
             ;;
     esac
 
-# Get command name
+    # Get command up to the cursor
     local token="${READLINE_LINE:0:${READLINE_POINT}}"
-# find first part of command line
+    # Remove everything before the last pipe
+    token=${token##*|}
+    # Strip leading whitespace
+    token="$(echo -e "${token}" | sed -e 's/^[[:space:]]*//')"
+    # Get the first word of token
     local cmd=${token%% *}
     # If we don't know about this program, skip it
     # don't redirect stderr since that is helpful


### PR DESCRIPTION
When writing a pipeline, the command you're most likely interested in getting help on is the one you're currently writing.  To address this, bashelp now removes the last `|`, `&`, or `;` character, everything before it, and all whitespace following it before parsing the command.  Very helpful for reviewing options to grep. 😉

Limitations: it doesn't understand the various things that would escape the delimiting characters.  It probably can't be correctly done in general with just a regular expression.